### PR TITLE
Relax cusolvermp run_exports to major+minor

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     sha256: "429772ba439da9ac1ea88989a0cc56f2f14b377af349129b1bf913e9357dbbd8"  # [linux and aarch64 and (cuda_compiler_version or "").startswith("13") and arm_variant_type == "sbsa"]
 
 build:
-  number: 2
+  number: 3
   skip: true  # [not (linux64 or aarch64)]
   skip: true  # [cuda_compiler_version in (None, "None") or (cuda_compiler_version or "").startswith("11")]
   script:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ outputs:
   - name: libcusolvermp{{ soname }}
     build:
       run_exports:
-        - {{ pin_subpackage("libcusolvermp" ~ soname, exact=True) }}
+        - {{ pin_subpackage("libcusolvermp" ~ soname, max_pin="x.x") }}
       ignore_run_exports_from:
         - libcusolver-dev
         - cuda-cudart-dev
@@ -74,7 +74,7 @@ outputs:
       ignore_run_exports:
         - cuda-version
       run_exports:
-        - {{ pin_subpackage("libcusolvermp" ~ soname, exact=True) }}
+        - {{ pin_subpackage("libcusolvermp" ~ soname, max_pin="x.x") }}
     files:
       - lib/libcusolverMp.so
       - include/cusolverMp.h


### PR DESCRIPTION
## Summary
- switch both libcusolvermp outputs to `pin_subpackage(..., max_pin="x.x")` so dependents only pin major+minor
- this allows downstreams to pick up cusolvermp patch releases without rebuilds

Closes #10

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase `@ conda-forge-admin, please rerender` in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
